### PR TITLE
Initialize .NET 8 billing service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # MsFacturacion
+
+Este repositorio contiene un microservicio de facturación desarrollado en .NET 8.
+
+El servicio expone una API REST para la emisión de comprobantes de pago y forma parte de un sistema HIS más grande.
+
+## Estructura del proyecto
+
+- `src/MsFacturacion.Api`: Proyecto principal de ASP.NET Core Web API.
+
+## Uso
+
+Debido a las restricciones del entorno, no se incluye el binario de .NET. Para compilar y ejecutar el microservicio localmente se necesita tener instalado el SDK de .NET 8:
+
+```bash
+cd src/MsFacturacion.Api
+# Restaurar y ejecutar
+# dotnet run
+```
+
+Al ejecutarse, la API expone un endpoint de prueba:
+
+```
+GET /api/billing/test
+```
+
+que devuelve un mensaje de confirmación.

--- a/src/MsFacturacion.Api/Controllers/BillingController.cs
+++ b/src/MsFacturacion.Api/Controllers/BillingController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace MsFacturacion.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class BillingController : ControllerBase
+{
+    [HttpGet("test")]
+    public IActionResult Test()
+    {
+        return Ok(new { message = "Billing service is running" });
+    }
+}

--- a/src/MsFacturacion.Api/MsFacturacion.Api.csproj
+++ b/src/MsFacturacion.Api/MsFacturacion.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/MsFacturacion.Api/Program.cs
+++ b/src/MsFacturacion.Api/Program.cs
@@ -1,0 +1,23 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+

--- a/src/MsFacturacion.Api/appsettings.json
+++ b/src/MsFacturacion.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- build an ASP.NET Core Web API skeleton for the billing microservice
- add a sample billing endpoint
- describe usage in README

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844ccfd0f50832da10eb0fcec29a707