### PR TITLE
Implement SQL Server persistence and validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Este repositorio contiene un microservicio de facturación desarrollado en .NET 
 
 El servicio expone una API REST para la emisión de comprobantes de pago y forma parte de un sistema HIS más grande. Se implementa siguiendo los principios de arquitectura limpia y el patrón CQRS.
 
+La capa de infraestructura puede utilizar **SQL Server** como base de datos gracias a Dapper. Si no se configura la cadena de conexión, el servicio emplea un repositorio en memoria.
+
 ## Estructura del proyecto
 
 - `src/MsFacturacion.Api`: Proyecto principal de ASP.NET Core Web API.
@@ -27,3 +29,19 @@ POST /api/billing/comprobantes
 ```
 
 El primero devuelve un mensaje de confirmación y el segundo permite registrar un nuevo comprobante.
+
+### Configuración de la base de datos
+
+1. Crear una base de datos llamada `MsFacturacion` en SQL Server y ejecutar el script `sql/create_comprobantes_table.sql` incluido en este repositorio.
+2. Modificar la cadena de conexión `ConnectionStrings:DefaultConnection` en `appsettings.json` con los datos de tu servidor.
+
+Si la cadena no se establece, el microservicio almacenará los comprobantes solo en memoria.
+
+### Validaciones
+
+La API valida los datos de entrada:
+
+- El RUC del emisor debe contener 11 dígitos.
+- La razón social es obligatoria y tiene un máximo de 100 caracteres.
+- El monto debe ser mayor a cero.
+

--- a/sql/create_comprobantes_table.sql
+++ b/sql/create_comprobantes_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE Comprobantes (
+    Id UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
+    Tipo INT NOT NULL,
+    RucEmisor NVARCHAR(11) NOT NULL,
+    RazonSocialEmisor NVARCHAR(100) NOT NULL,
+    Monto DECIMAL(18,2) NOT NULL,
+    FechaEmision DATETIME2 NOT NULL
+);

--- a/src/MsFacturacion.Api/Controllers/BillingController.cs
+++ b/src/MsFacturacion.Api/Controllers/BillingController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
 using MsFacturacion.Api.Application;
 using MsFacturacion.Api.Domain;
 
@@ -57,10 +58,9 @@ public class BillingController : ControllerBase
 /// <summary>
 /// DTO de entrada para crear comprobantes.
 /// </summary>
-public record ComprobanteDto
-(
-    TipoComprobante Tipo,
-    string RucEmisor,
-    string RazonSocialEmisor,
-    decimal Monto
+public record ComprobanteDto(
+    [Required] TipoComprobante Tipo,
+    [Required, RegularExpression(@"^\d{11}$")] string RucEmisor,
+    [Required, StringLength(100)] string RazonSocialEmisor,
+    [Range(0.01, double.MaxValue)] decimal Monto
 );

--- a/src/MsFacturacion.Api/Infrastructure/SqlServerComprobanteRepository.cs
+++ b/src/MsFacturacion.Api/Infrastructure/SqlServerComprobanteRepository.cs
@@ -1,0 +1,40 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using MsFacturacion.Api.Application;
+using MsFacturacion.Api.Domain;
+
+namespace MsFacturacion.Api.Infrastructure;
+
+/// <summary>
+/// Implementación de <see cref="IComprobanteRepository"/> usando SQL Server.
+/// </summary>
+public class SqlServerComprobanteRepository : IComprobanteRepository
+{
+    private readonly string _connectionString;
+
+    public SqlServerComprobanteRepository(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    private IDbConnection CreateConnection() => new SqlConnection(_connectionString);
+
+    public void Add(Comprobante comprobante)
+    {
+        using var connection = CreateConnection();
+        const string sql = @"INSERT INTO Comprobantes
+                             (Id, Tipo, RucEmisor, RazonSocialEmisor, Monto, FechaEmision)
+                             VALUES (@Id, @Tipo, @RucEmisor, @RazonSocialEmisor, @Monto, @FechaEmision)";
+        connection.Execute(sql, comprobante);
+    }
+
+    public Comprobante? GetById(Guid id)
+    {
+        using var connection = CreateConnection();
+        const string sql = @"SELECT Id, Tipo, RucEmisor, RazonSocialEmisor, Monto, FechaEmision
+                             FROM Comprobantes WHERE Id = @Id";
+        return connection.QueryFirstOrDefault<Comprobante>(sql, new { Id = id });
+    }
+}
+

--- a/src/MsFacturacion.Api/MsFacturacion.Api.csproj
+++ b/src/MsFacturacion.Api/MsFacturacion.Api.csproj
@@ -4,4 +4,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+  </ItemGroup>
 </Project>

--- a/src/MsFacturacion.Api/Program.cs
+++ b/src/MsFacturacion.Api/Program.cs
@@ -5,8 +5,16 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 
-// Registro de dependencias siguiendo la arquitectura limpia
-builder.Services.AddSingleton<IComprobanteRepository, InMemoryComprobanteRepository>();
+// Registro de dependencias con soporte para SQL Server o en memoria
+var connection = builder.Configuration.GetConnectionString("DefaultConnection");
+if (!string.IsNullOrEmpty(connection))
+{
+    builder.Services.AddScoped<IComprobanteRepository>(sp => new SqlServerComprobanteRepository(connection));
+}
+else
+{
+    builder.Services.AddSingleton<IComprobanteRepository, InMemoryComprobanteRepository>();
+}
 builder.Services.AddScoped<ComprobanteService>();
 
 builder.Services.AddEndpointsApiExplorer();

--- a/src/MsFacturacion.Api/appsettings.json
+++ b/src/MsFacturacion.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=MsFacturacion;Trusted_Connection=True;TrustServerCertificate=True;"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- introduce `SqlServerComprobanteRepository` using Dapper
- add package references for Dapper and Microsoft.Data.SqlClient
- register SQL Server repository when a connection string is provided
- add input validations via DataAnnotations
- add SQL schema script and update documentation

## Testing
- `dotnet build src/MsFacturacion.Api/MsFacturacion.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6166b4c832d90853d6d2de29476